### PR TITLE
art: implement Overlaps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/tailscale/art
 go 1.20
 
 require github.com/google/go-cmp v0.6.0
+
+require go4.org/netipx v0.0.0-20230824141953-6213f710f925 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+go4.org/netipx v0.0.0-20230824141953-6213f710f925 h1:eeQDDVKFkx0g4Hyy8pHgmZaK0EqB4SD6rvKbUdN3ziQ=
+go4.org/netipx v0.0.0-20230824141953-6213f710f925/go.mod h1:PLyyIXexvUFg3Owu6p/WfdlivPbZJsZdgWZlrGope/Y=

--- a/stride_table.go
+++ b/stride_table.go
@@ -223,6 +223,16 @@ func (t *strideTable[T]) getValAndChild(addr uint8) (val T, valOK bool, child *s
 	return
 }
 
+func (t *strideTable[T]) entriesOverlap(o *strideTable[T]) bool {
+	for i := firstHostIndex; i <= lastHostIndex; i++ {
+		if t.entries[i] != nil && o.entries[i] != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 // overlapsPrefix reports whether the route addr/prefixLen overlaps
 // with any prefix in t.
 func (t *strideTable[T]) overlapsPrefix(addr uint8, prefixLen int) bool {


### PR DESCRIPTION
Diffing against the other PR, just so it only shows the differences.

Sadly, right now, Overlaps is correct, but slower than netipx.IPset: about 40% slower for IPv4, and around 10x slower (!) for IPv6. I don't know why the massive diff for IPv6 yet, that has to be a bug of some kind. And the whole implementation is focused on understanding the algorithm rather than going fast, so hopefully there's some really obvious speedups available? :crossed_fingers: 